### PR TITLE
Fix to MTTR, when the start and end dates are further apart

### DIFF
--- a/DevOpsMetrics/DevOpsMetrics.Service/DataAccess/MeanTimeToRestoreDA.cs
+++ b/DevOpsMetrics/DevOpsMetrics.Service/DataAccess/MeanTimeToRestoreDA.cs
@@ -74,7 +74,8 @@ namespace DevOpsMetrics.Service.DataAccess
                     {
                         if (endingAlerts[j].name == item.Name
                             && endingAlerts[j].resourceName == item.Resource
-                            && endingAlerts[j].resourceGroupName == item.ResourceGroup)
+                            && endingAlerts[j].resourceGroupName == item.ResourceGroup
+                            && endingAlerts[j].timestamp > item.StartTime)
                         {
                             item.EndTime = endingAlerts[j].timestamp;
                             item.Status = "completed";


### PR DESCRIPTION
 - sometimes causing the wrong alerts to match.

Fixes #107 