### PR TITLE
Parallel processing

### DIFF
--- a/src/DevOpsMetrics.Cmd/Program.cs
+++ b/src/DevOpsMetrics.Cmd/Program.cs
@@ -76,7 +76,7 @@ namespace DevOpsMetrics.Cmd
                         ghSetting.WorkflowName, ghSetting.WorkflowId,
                         ghSetting.ProductionResourceGroup,
                         numberOfDays, maxNumberOfItems,
-                        null, true, true, true);
+                        null, true, true, false);
                     totalResults = ghResult.TotalResults;
                 }
             }

--- a/src/DevOpsMetrics.Cmd/Program.cs
+++ b/src/DevOpsMetrics.Cmd/Program.cs
@@ -6,7 +6,6 @@ using DevOpsMetrics.Service;
 using DevOpsMetrics.Service.Controllers;
 using Microsoft.Azure.KeyVault;
 using Microsoft.Azure.Services.AppAuthentication;
-using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -44,8 +43,8 @@ namespace DevOpsMetrics.Cmd
             AzureTableStorageDA azureTableStorageDA = new();
             SettingsController settingsController = new(Configuration, new AzureTableStorageDA());
             DORASummaryController doraSummaryController = new(Configuration);
-            List<AzureDevOpsSettings> azSettings = settingsController.GetAzureDevOpsSettings();
-            List<GitHubSettings> ghSettings = settingsController.GetGitHubSettings();
+            List<AzureDevOpsSettings> azSettings = await settingsController.GetAzureDevOpsSettings();
+            List<GitHubSettings> ghSettings = await settingsController.GetGitHubSettings();
             TableStorageConfiguration tableStorageConfig = Common.GenerateTableStorageConfiguration(Configuration);
 
             //Loop through each setting to update the runs, pull requests and pull request commits

--- a/src/DevOpsMetrics.Cmd/Program.cs
+++ b/src/DevOpsMetrics.Cmd/Program.cs
@@ -1,96 +1,75 @@
-﻿//Commented out, 22-May 2023, as this the usage of this is not clear and it is causing build errors
+﻿using DevOpsMetrics.Core.DataAccess.TableStorage;
+using DevOpsMetrics.Core.Models.AzureDevOps;
+using DevOpsMetrics.Core.Models.Common;
+using DevOpsMetrics.Core.Models.GitHub;
+using DevOpsMetrics.Service;
+using Microsoft.Azure.KeyVault;
+using Microsoft.Azure.Services.AppAuthentication;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
 namespace DevOpsMetrics.Cmd
 {
     internal class Program
     {
         static async Task Main()
         {
+            DateTime startTime = DateTime.Now;
+            Console.WriteLine($"C# Timer trigger function UpdateStorageTables started at: {startTime}");
+
+            //Load settings
+            IConfigurationBuilder? builder = new ConfigurationBuilder()
+                 .SetBasePath(Directory.GetCurrentDirectory())
+                 .AddJsonFile("appsettings.json", optional: false)
+                 .AddUserSecrets<Program>(true);
+            IConfigurationRoot Configuration = builder.Build();
+            ILogger log = new Logger<Program>(new LoggerFactory());
+
+            string keyVaultURL = Configuration["AppSettings:KeyVaultURL"];
+            string keyVaultId = Configuration["AppSettings:KeyVaultClientId"];
+            string keyVaultSecret = Configuration["AppSettings:KeyVaultClientSecret"];
+            AzureServiceTokenProvider azureServiceTokenProvider = new();
+            KeyVaultClient keyVaultClient = new(new KeyVaultClient.AuthenticationCallback(azureServiceTokenProvider.KeyVaultTokenCallback));
+            builder.AddAzureKeyVault(keyVaultURL, keyVaultId, keyVaultSecret);
+            Configuration = builder.Build();
+            ServiceApiClient serviceApiClient = new(Configuration);
+
+            //Get settings
+            string clientId = Configuration["AppSettings:GitHubClientId"];
+            string clientSecret = Configuration["AppSettings:GitHubClientSecret"];
+            AzureTableStorageDA azureTableStorageDA = new();
+            List<AzureDevOpsSettings> azSettings = await serviceApiClient.GetAzureDevOpsSettings();
+            List<GitHubSettings> ghSettings = await serviceApiClient.GetGitHubSettings();
+            TableStorageConfiguration tableStorageConfig = Common.GenerateTableStorageConfiguration(Configuration);
+
+            //Loop through each setting to update the runs, pull requests and pull request commits
+            int numberOfDays = 30;
+            int maxNumberOfItems = 20;
+            int totalResults = 0;
+            foreach (AzureDevOpsSettings azSetting in azSettings)
+            {
+                log.LogInformation($"Processing Azure DevOps organization {azSetting.Organization}, project {azSetting.Project}");
+                ProcessingResult ghResult = await serviceApiClient.UpdateDORASummaryItem(
+                    azSetting.Organization, azSetting.Project, azSetting.Repository,
+                    azSetting.Branch, azSetting.BuildName, azSetting.BuildId,
+                    azSetting.ProductionResourceGroup,
+                    numberOfDays, maxNumberOfItems, false);
+                totalResults = ghResult.TotalResults;
+            }
+
+            foreach (GitHubSettings ghSetting in ghSettings)
+            {
+                log.LogInformation($"Processing GitHub owner {ghSetting.Owner}, repo {ghSetting.Repo}");
+                ProcessingResult ghResult = await serviceApiClient.UpdateDORASummaryItem(
+                    ghSetting.Owner, "", ghSetting.Repo, ghSetting.Branch,
+                    ghSetting.WorkflowName, ghSetting.WorkflowId,
+                    ghSetting.ProductionResourceGroup,
+                    numberOfDays, maxNumberOfItems, true);
+                totalResults = ghResult.TotalResults;
+            }
+            DateTime endTime = DateTime.Now;
+            Console.WriteLine($"C# Timer trigger function complete at: {endTime} after updating {totalResults} records");
+            Console.WriteLine($"Processing finished in {(endTime - startTime).TotalSeconds}");
         }
     }
 }
-
-//using DevOpsMetrics.Core.DataAccess.TableStorage;
-//using DevOpsMetrics.Core.Models.AzureDevOps;
-//using DevOpsMetrics.Core.Models.Common;
-//using DevOpsMetrics.Core.Models.GitHub;
-//using DevOpsMetrics.Service;
-//using DevOpsMetrics.Service.Controllers;
-//using Microsoft.Azure.KeyVault;
-//using Microsoft.Azure.Services.AppAuthentication;
-//using Microsoft.Extensions.Configuration;
-//using Microsoft.Extensions.Logging;
-
-//namespace DevOpsMetrics.Cmd
-//{
-//    internal class Program
-//    {
-//        static async Task Main()
-//        {
-//            Console.WriteLine($"C# Timer trigger function UpdateStorageTables started at: {DateTime.Now}");
-
-//            //Load settings
-//            IConfigurationBuilder? builder = new ConfigurationBuilder()
-//                 .SetBasePath(Directory.GetCurrentDirectory())
-//                 .AddJsonFile("appsettings.json", optional: false)
-//                 .AddUserSecrets<Program>(true);
-//            IConfigurationRoot Configuration = builder.Build();
-//            ILogger log = new Logger<Program>(new LoggerFactory());
-
-//            string keyVaultURL = Configuration["AppSettings:KeyVaultURL"];
-//            string keyVaultId = Configuration["AppSettings:KeyVaultClientId"];
-//            string keyVaultSecret = Configuration["AppSettings:KeyVaultClientSecret"];
-//            AzureServiceTokenProvider azureServiceTokenProvider = new();
-//            KeyVaultClient keyVaultClient = new(new KeyVaultClient.AuthenticationCallback(azureServiceTokenProvider.KeyVaultTokenCallback));
-//            builder.AddAzureKeyVault(keyVaultURL, keyVaultId, keyVaultSecret);
-//            Configuration = builder.Build();
-
-//            //Get settings
-//            string clientId = Configuration["AppSettings:GitHubClientId"];
-//            string clientSecret = Configuration["AppSettings:GitHubClientSecret"];
-//            AzureTableStorageDA azureTableStorageDA = new();
-//            SettingsController settingsController = new(Configuration, azureTableStorageDA);
-//            DORASummaryController doraSummaryController = new(Configuration);
-//            List<AzureDevOpsSettings> azSettings = settingsController.GetAzureDevOpsSettings();
-//            List<GitHubSettings> ghSettings = settingsController.GetGitHubSettings();
-//            TableStorageConfiguration tableStorageConfig = Common.GenerateTableStorageConfiguration(Configuration);
-
-//            //Loop through each setting to update the runs, pull requests and pull request commits
-//            int numberOfDays = 30;
-//            int maxNumberOfItems = 20;
-//            int totalResults = 0;
-//            foreach (AzureDevOpsSettings item in azSettings)
-//            {
-//                //    (int, string) buildsUpdated = (0, null);
-//                //    (int, string) prsUpdated = (0, null);
-//                //    try
-//                //    {
-//                Console.WriteLine($"Processing Azure DevOps organization {item.Organization}, project {item.Project}");
-//                //        buildsUpdated = await api.UpdateAzureDevOpsBuilds(item.Organization, item.Project, item.Repository, item.Branch, item.BuildName, item.BuildId, numberOfDays, maxNumberOfItems);
-//                //        prsUpdated = await api.UpdateAzureDevOpsPullRequests(item.Organization, item.Project, item.Repository, numberOfDays, maxNumberOfItems);
-//                //        log.LogInformation($"Processed Azure DevOps organization {item.Organization}, project {item.Project}. {buildsUpdated.Item1} builds and {prsUpdated.Item1} prs/commits updated");
-//                //        totalResults += buildsUpdated.Item1 + prsUpdated.Item1;
-//                //        await api.UpdateAzureDevOpsProjectLog(item.Organization, item.Project, item.Repository, buildsUpdated.Item1, prsUpdated.Item1, buildsUpdated.Item2, prsUpdated.Item2, null, null);
-//                //    }
-//                //    catch (Exception ex)
-//                //    {
-//                //        string error = $"Exception while processing Azure DevOps organization {item.Organization}, project {item.Project}. {buildsUpdated.Item1} builds and {prsUpdated.Item1} prs/commits updated";
-//                //        log.LogInformation(error);
-//                //        await api.UpdateAzureDevOpsProjectLog(item.Organization, item.Project, item.Repository, buildsUpdated.Item1, prsUpdated.Item1, buildsUpdated.Item2, prsUpdated.Item2, ex.Message, error);
-//                //    }
-//            }
-
-//            foreach (GitHubSettings ghSetting in ghSettings)
-//            {
-//                ProcessingResult ghResult = await doraSummaryController.UpdateDORASummaryItem(
-//                    ghSetting.Owner, ghSetting.Repo, ghSetting.Branch,
-//                    ghSetting.WorkflowName, ghSetting.WorkflowId,
-//                    ghSetting.ProductionResourceGroup,
-//                    numberOfDays, maxNumberOfItems,
-//                    log, true);
-//                totalResults += ghResult.TotalResults;
-//            }
-//            Console.WriteLine($"C# Timer trigger function complete at: {DateTime.Now} after updating {totalResults} records");
-
-//        }
-//    }
-//}

--- a/src/DevOpsMetrics.Cmd/Program.cs
+++ b/src/DevOpsMetrics.Cmd/Program.cs
@@ -5,6 +5,7 @@ using DevOpsMetrics.Core.Models.GitHub;
 using DevOpsMetrics.Service;
 using Microsoft.Azure.KeyVault;
 using Microsoft.Azure.Services.AppAuthentication;
+using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -12,6 +13,8 @@ namespace DevOpsMetrics.Cmd
 {
     internal class Program
     {
+        private static string ProjectId = "DeveloperMetrics_DevOpsMetrics";
+
         static async Task Main()
         {
             DateTime startTime = DateTime.Now;
@@ -48,24 +51,30 @@ namespace DevOpsMetrics.Cmd
             int totalResults = 0;
             foreach (AzureDevOpsSettings azSetting in azSettings)
             {
-                log.LogInformation($"Processing Azure DevOps organization {azSetting.Organization}, project {azSetting.Project}");
-                ProcessingResult ghResult = await serviceApiClient.UpdateDORASummaryItem(
-                    azSetting.Organization, azSetting.Project, azSetting.Repository,
-                    azSetting.Branch, azSetting.BuildName, azSetting.BuildId,
-                    azSetting.ProductionResourceGroup,
-                    numberOfDays, maxNumberOfItems, false);
-                totalResults = ghResult.TotalResults;
+                if (ProjectId == azSetting.RowKey)
+                {
+                    log.LogInformation($"Processing Azure DevOps organization {azSetting.Organization}, project {azSetting.Project}");
+                    ProcessingResult ghResult = await serviceApiClient.UpdateDORASummaryItem(
+                        azSetting.Organization, azSetting.Project, azSetting.Repository,
+                        azSetting.Branch, azSetting.BuildName, azSetting.BuildId,
+                        azSetting.ProductionResourceGroup,
+                        numberOfDays, maxNumberOfItems, false);
+                    totalResults = ghResult.TotalResults;
+                }
             }
 
             foreach (GitHubSettings ghSetting in ghSettings)
             {
-                log.LogInformation($"Processing GitHub owner {ghSetting.Owner}, repo {ghSetting.Repo}");
-                ProcessingResult ghResult = await serviceApiClient.UpdateDORASummaryItem(
-                    ghSetting.Owner, "", ghSetting.Repo, ghSetting.Branch,
-                    ghSetting.WorkflowName, ghSetting.WorkflowId,
-                    ghSetting.ProductionResourceGroup,
-                    numberOfDays, maxNumberOfItems, true);
-                totalResults = ghResult.TotalResults;
+                if (ProjectId == ghSetting.RowKey)
+                {
+                    log.LogInformation($"Processing GitHub owner {ghSetting.Owner}, repo {ghSetting.Repo}");
+                    ProcessingResult ghResult = await serviceApiClient.UpdateDORASummaryItem(
+                        ghSetting.Owner, "", ghSetting.Repo, ghSetting.Branch,
+                        ghSetting.WorkflowName, ghSetting.WorkflowId,
+                        ghSetting.ProductionResourceGroup,
+                        numberOfDays, maxNumberOfItems, true);
+                    totalResults = ghResult.TotalResults;
+                }
             }
             DateTime endTime = DateTime.Now;
             Console.WriteLine($"C# Timer trigger function complete at: {endTime} after updating {totalResults} records");

--- a/src/DevOpsMetrics.Cmd/Program.cs
+++ b/src/DevOpsMetrics.Cmd/Program.cs
@@ -76,7 +76,7 @@ namespace DevOpsMetrics.Cmd
                         ghSetting.WorkflowName, ghSetting.WorkflowId,
                         ghSetting.ProductionResourceGroup,
                         numberOfDays, maxNumberOfItems,
-                        null, true, true, false);
+                        null, true, true, true);
                     totalResults = ghResult.TotalResults;
                 }
             }

--- a/src/DevOpsMetrics.Cmd/ServiceApiClient.cs
+++ b/src/DevOpsMetrics.Cmd/ServiceApiClient.cs
@@ -1,0 +1,98 @@
+﻿using System.Diagnostics;
+using System.Text;
+using DevOpsMetrics.Core.Models.AzureDevOps;
+using DevOpsMetrics.Core.Models.Common;
+using DevOpsMetrics.Core.Models.GitHub;
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+
+namespace DevOpsMetrics.Cmd
+{
+    public class ServiceApiClient
+    {
+        private readonly IConfiguration Configuration;
+        private readonly HttpClient Client;
+
+        public ServiceApiClient(IConfiguration configuration)
+        {
+            Configuration = configuration;
+            Client = new HttpClient
+            {
+                BaseAddress = new Uri(Configuration["AppSettings:WebServiceURL"])
+            };
+        }
+
+        public async Task<List<AzureDevOpsSettings>> GetAzureDevOpsSettings()
+        {
+            string url = $"/api/Settings/GetAzureDevOpsSettings";
+            return await GetResponse<List<AzureDevOpsSettings>>(Client, url);
+        }
+
+        public async Task<List<GitHubSettings>> GetGitHubSettings()
+        {
+            string url = $"/api/Settings/GetGitHubSettings";
+            return await GetResponse<List<GitHubSettings>>(Client, url);
+        }
+
+        public async Task<ProcessingResult> UpdateDORASummaryItem(
+            string owner, string project, string repository, 
+            string branch, string workflowName, string workflowId, 
+            string resourceGroup, int numberOfDays, int maxNumberOfItems,            
+            bool isGitHub = true)
+        {
+            string url = $"/api/DORASummary/UpdateDORASummaryItem?owner={owner}&project={project}&repository={repository}&branch={branch}&workflowName={workflowName}&workflowId={workflowId}&resourceGroup={resourceGroup}&numberOfDays={numberOfDays}&maxNumberOfItems={maxNumberOfItems}&log=&useCache=true&isGitHub={isGitHub}";
+            return await GetResponse<ProcessingResult>(Client, url);
+        }
+
+        public async Task<bool> UpdateDevOpsMonitoringEvent(MonitoringEvent monitoringEvent)
+        {
+            string url = $"/api/Settings/UpdateDevOpsMonitoringEvent";
+            return await PostResponse(Client, url, monitoringEvent);
+        }
+
+        private async Task<T> GetResponse<T>(HttpClient client, string url)
+        {
+            T obj = default;
+            if (client != null && url != null)
+            {
+                Debug.WriteLine("Running url: " + client.BaseAddress.ToString() + url);
+                using (HttpResponseMessage response = await client.GetAsync(url))
+                {
+                    //TODO: Add a flag in the service to turn this on and off.
+                    if (response.IsSuccessStatusCode == false)
+                    {
+                        //Log the URL to help with debugging
+                    }
+                    response.EnsureSuccessStatusCode();
+                    string responseBody = await response.Content.ReadAsStringAsync();
+                    if (string.IsNullOrEmpty(responseBody) == false)
+                    {
+                        obj = JsonConvert.DeserializeObject<T>(responseBody);
+                    }
+                }
+            }
+            return obj;
+        }
+
+        private async Task<bool> PostResponse(HttpClient client, string url, MonitoringEvent monitoringEvent)
+        {
+
+            if (client != null && url != null)
+            {
+                StringContent content = new StringContent(JsonConvert.SerializeObject(monitoringEvent), Encoding.UTF8, "application/json");
+
+                Debug.WriteLine("Running url: " + client.BaseAddress.ToString() + url);
+                using (HttpResponseMessage response = await client.PostAsync(url, content))
+                {
+                    response.EnsureSuccessStatusCode();
+                    //string responseBody = await response.Content.ReadAsStringAsync();
+                    //if (string.IsNullOrEmpty(responseBody) == false)
+                    //{
+                    //    obj = JsonConvert.DeserializeObject<T>(responseBody);
+                    //}
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/src/DevOpsMetrics.Core/DataAccess/BuildsDA.cs
+++ b/src/DevOpsMetrics.Core/DataAccess/BuildsDA.cs
@@ -22,7 +22,7 @@ namespace DevOpsMetrics.Core.DataAccess
             {
                 //Get the builds from Azure storage
                 AzureTableStorageDA daTableStorage = new();
-                list = daTableStorage.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableAzureDevOpsBuilds, PartitionKeys.CreateBuildWorkflowPartitionKey(organization, project, buildName));
+                list = await daTableStorage.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableAzureDevOpsBuilds, PartitionKeys.CreateBuildWorkflowPartitionKey(organization, project, buildName));
             }
             else
             {
@@ -55,7 +55,7 @@ namespace DevOpsMetrics.Core.DataAccess
             {
                 //Get the builds from Azure storage
                 AzureTableStorageDA daTableStorage = new();
-                list = daTableStorage.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableGitHubRuns, PartitionKeys.CreateBuildWorkflowPartitionKey(owner, repo, workflowName));
+                list = await daTableStorage.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableGitHubRuns, PartitionKeys.CreateBuildWorkflowPartitionKey(owner, repo, workflowName));
             }
             else
             {

--- a/src/DevOpsMetrics.Core/DataAccess/ChangeFailureRateDA.cs
+++ b/src/DevOpsMetrics.Core/DataAccess/ChangeFailureRateDA.cs
@@ -12,7 +12,7 @@ namespace DevOpsMetrics.Core.DataAccess
 {
     public class ChangeFailureRateDA
     {
-        public static ChangeFailureRateModel GetChangeFailureRate(bool getSampleData, TableStorageConfiguration tableStorageConfig,
+        public static async Task<ChangeFailureRateModel> GetChangeFailureRate(bool getSampleData, TableStorageConfiguration tableStorageConfig,
                 DevOpsPlatform targetDevOpsPlatform, string organization_owner, string project_repo, string branch, string buildName_workflowName,
                 int numberOfDays, int maxNumberOfItems)
         {
@@ -22,7 +22,7 @@ namespace DevOpsMetrics.Core.DataAccess
             {
                 //Gets a list of change failure rate builds from Azure storage
                 AzureTableStorageDA daTableStorage = new();
-                JArray list = daTableStorage.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableChangeFailureRate, PartitionKeys.CreateBuildWorkflowPartitionKey(organization_owner, project_repo, buildName_workflowName));
+                JArray list = await daTableStorage.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableChangeFailureRate, PartitionKeys.CreateBuildWorkflowPartitionKey(organization_owner, project_repo, buildName_workflowName));
                 List<ChangeFailureRateBuild> initialBuilds = JsonConvert.DeserializeObject<List<ChangeFailureRateBuild>>(list.ToString());
 
                 //Build the date list and then generate the change failure rate metric
@@ -106,7 +106,7 @@ namespace DevOpsMetrics.Core.DataAccess
             //Gets a list of change failure rate builds
             AzureTableStorageDA daTableStorage = new();
             string partitionKey = PartitionKeys.CreateBuildWorkflowPartitionKey(organization_owner, project_repo, buildName_workflowName);
-            JArray list = daTableStorage.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableChangeFailureRate, partitionKey);
+            JArray list = await daTableStorage.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableChangeFailureRate, partitionKey);
             List<ChangeFailureRateBuild> initialBuilds = JsonConvert.DeserializeObject<List<ChangeFailureRateBuild>>(list.ToString());
 
             //Get the list of items we are going to process, within the date/day range

--- a/src/DevOpsMetrics.Core/DataAccess/DORASummaryDA.cs
+++ b/src/DevOpsMetrics.Core/DataAccess/DORASummaryDA.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using DevOpsMetrics.Core.DataAccess.TableStorage;
 using DevOpsMetrics.Core.Models.Common;
 using Newtonsoft.Json;
@@ -8,20 +9,20 @@ namespace DevOpsMetrics.Core.DataAccess
 {
     public class DORASummaryDA
     {
-        public static List<DORASummaryItem> GetDORASummaryItems(TableStorageConfiguration tableStorageConfig,
+        public static async Task<List<DORASummaryItem>> GetDORASummaryItems(TableStorageConfiguration tableStorageConfig,
                 string owner)
         {
             AzureTableStorageDA da = new();
-            JArray list = da.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableDORASummaryItem, owner);
+            JArray list = await da.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableDORASummaryItem, owner);
             List<DORASummaryItem> doraItems = JsonConvert.DeserializeObject<List<DORASummaryItem>>(list.ToString());
             return doraItems;
         }
 
-        public static DORASummaryItem GetDORASummaryItem(TableStorageConfiguration tableStorageConfig,
+        public static async Task<DORASummaryItem> GetDORASummaryItem(TableStorageConfiguration tableStorageConfig,
                 string owner, string repo)
         {
             DORASummaryItem result = null;
-            List<DORASummaryItem> doraItems = GetDORASummaryItems(tableStorageConfig, owner);
+            List<DORASummaryItem> doraItems = await GetDORASummaryItems(tableStorageConfig, owner);
             foreach (DORASummaryItem item in doraItems)
             {
                 if (item.Repo.ToLower() == repo.ToLower())
@@ -32,8 +33,6 @@ namespace DevOpsMetrics.Core.DataAccess
             }
             return result;
         }
-
-
 
     }
 }

--- a/src/DevOpsMetrics.Core/DataAccess/MeanTimeToRestoreDA.cs
+++ b/src/DevOpsMetrics.Core/DataAccess/MeanTimeToRestoreDA.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using DevOpsMetrics.Core.DataAccess.Common;
 using DevOpsMetrics.Core.DataAccess.TableStorage;
 using DevOpsMetrics.Core.Models.Azure;
@@ -11,7 +12,7 @@ namespace DevOpsMetrics.Core.DataAccess
 {
     public class MeanTimeToRestoreDA
     {
-        public static MeanTimeToRestoreModel GetAzureMeanTimeToRestore(bool getSampleData,
+        public static async Task<MeanTimeToRestoreModel> GetAzureMeanTimeToRestore(bool getSampleData,
                 TableStorageConfiguration tableStorageConfig,
                 DevOpsPlatform targetDevOpsPlatform, string resourceGroup,
                 int numberOfDays, int maxNumberOfItems)
@@ -27,7 +28,7 @@ namespace DevOpsMetrics.Core.DataAccess
 
                 //Pull the events from the table storage
                 AzureTableStorageDA daTableStorage = new();
-                JArray list = daTableStorage.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableMTTR, resourceGroup);
+                JArray list = await daTableStorage.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableMTTR, resourceGroup);
                 List<AzureAlert> alerts = new();
                 foreach (JToken item in list)
                 {

--- a/src/DevOpsMetrics.Core/DataAccess/PullRequestsDA.cs
+++ b/src/DevOpsMetrics.Core/DataAccess/PullRequestsDA.cs
@@ -21,7 +21,7 @@ namespace DevOpsMetrics.Core.DataAccess
             {
                 //Get the pull requests from Azure storage
                 AzureTableStorageDA daTableStorage = new();
-                list = daTableStorage.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableAzureDevOpsPRs, PartitionKeys.CreateGitHubPRPartitionKey(organization, project));
+                list = await daTableStorage.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableAzureDevOpsPRs, PartitionKeys.CreateGitHubPRPartitionKey(organization, project));
             }
             else
             {
@@ -53,7 +53,7 @@ namespace DevOpsMetrics.Core.DataAccess
             {
                 //Get the commits from Azure storage
                 AzureTableStorageDA daTableStorage = new();
-                list = daTableStorage.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableAzureDevOpsPRCommits, PartitionKeys.CreateAzureDevOpsPRCommitPartitionKey(organization, project, pullRequestId));
+                list = await daTableStorage.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableAzureDevOpsPRCommits, PartitionKeys.CreateAzureDevOpsPRCommitPartitionKey(organization, project, pullRequestId));
             }
             else
             {
@@ -73,7 +73,7 @@ namespace DevOpsMetrics.Core.DataAccess
             {
                 //Get the pull requests from Azure storage
                 AzureTableStorageDA daTableStorage = new();
-                list = daTableStorage.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableGitHubPRs, PartitionKeys.CreateGitHubPRPartitionKey(owner, repo));
+                list = await daTableStorage.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableGitHubPRs, PartitionKeys.CreateGitHubPRPartitionKey(owner, repo));
             }
             else
             {
@@ -105,7 +105,7 @@ namespace DevOpsMetrics.Core.DataAccess
             {
                 //Get the commits from Azure storage
                 AzureTableStorageDA daTableStorage = new();
-                list = daTableStorage.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableGitHubPRCommits, PartitionKeys.CreateGitHubPRCommitPartitionKey(owner, repo, pull_number));
+                list = await daTableStorage.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableGitHubPRCommits, PartitionKeys.CreateGitHubPRCommitPartitionKey(owner, repo, pull_number));
             }
             else
             {

--- a/src/DevOpsMetrics.Core/DataAccess/TableStorage/AzureTableStorageDA.cs
+++ b/src/DevOpsMetrics.Core/DataAccess/TableStorage/AzureTableStorageDA.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -24,10 +23,10 @@ namespace DevOpsMetrics.Core.DataAccess.TableStorage
         /// <param name="partitionKey">Partition key to filter by</param>
         /// <param name="includePartitionAndRowKeys">Include Partition and row key metadata (for debugging)</param>
         /// <returns></returns>
-        public JArray GetTableStorageItemsFromStorage(TableStorageConfiguration tableStorageConfig, string tableName, string partitionKey, bool includePartitionAndRowKeys = false)
+        public async Task<JArray> GetTableStorageItemsFromStorage(TableStorageConfiguration tableStorageConfig, string tableName, string partitionKey, bool includePartitionAndRowKeys = false)
         {
             TableStorageCommonDA tableDA = new(tableStorageConfig.StorageAccountConnectionString, tableName);
-            List<AzureStorageTableModel> items = tableDA.GetItems(partitionKey);
+            List<AzureStorageTableModel> items = await tableDA.GetItems(partitionKey);
             JArray list = new();
             foreach (AzureStorageTableModel item in items)
             {
@@ -49,11 +48,11 @@ namespace DevOpsMetrics.Core.DataAccess.TableStorage
             return list;
         }
 
-        public List<AzureDevOpsSettings> GetAzureDevOpsSettingsFromStorage(TableStorageConfiguration tableStorageConfig, string settingsTable, string rowKey)
+        public async Task<List<AzureDevOpsSettings>> GetAzureDevOpsSettingsFromStorage(TableStorageConfiguration tableStorageConfig, string settingsTable, string rowKey)
         {
             List<AzureDevOpsSettings> settings = null;
             string partitionKey = "AzureDevOpsSettings";
-            JArray list = GetTableStorageItemsFromStorage(tableStorageConfig, settingsTable, partitionKey);
+            JArray list = await GetTableStorageItemsFromStorage(tableStorageConfig, settingsTable, partitionKey);
             if (list != null)
             {
                 settings = JsonConvert.DeserializeObject<List<AzureDevOpsSettings>>(list.ToString());
@@ -71,11 +70,11 @@ namespace DevOpsMetrics.Core.DataAccess.TableStorage
             }
         }
 
-        public List<GitHubSettings> GetGitHubSettingsFromStorage(TableStorageConfiguration tableStorageConfig, string settingsTable, string rowKey)
+        public async Task<List<GitHubSettings>> GetGitHubSettingsFromStorage(TableStorageConfiguration tableStorageConfig, string settingsTable, string rowKey)
         {
             List<GitHubSettings> settings = null;
             string partitionKey = "GitHubSettings";
-            JArray list = GetTableStorageItemsFromStorage(tableStorageConfig, settingsTable, partitionKey);
+            JArray list = await GetTableStorageItemsFromStorage(tableStorageConfig, settingsTable, partitionKey);
             if (list != null)
             {
                 settings = JsonConvert.DeserializeObject<List<GitHubSettings>>(list.ToString());
@@ -93,10 +92,10 @@ namespace DevOpsMetrics.Core.DataAccess.TableStorage
             }
         }
 
-        public List<ProjectLog> GetProjectLogsFromStorage(TableStorageConfiguration tableStorageConfig, string partitionKey)
+        public async Task<List<ProjectLog>> GetProjectLogsFromStorage(TableStorageConfiguration tableStorageConfig, string partitionKey)
         {
             List<ProjectLog> logs = null;
-            JArray list = GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableLog, partitionKey, true);
+            JArray list = await GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableLog, partitionKey, true);
             if (list != null)
             {
                 logs = JsonConvert.DeserializeObject<List<ProjectLog>>(list.ToString());

--- a/src/DevOpsMetrics.Core/DataAccess/TableStorage/IAzureTableStorageDA.cs
+++ b/src/DevOpsMetrics.Core/DataAccess/TableStorage/IAzureTableStorageDA.cs
@@ -9,9 +9,9 @@ namespace DevOpsMetrics.Core.DataAccess.TableStorage
 {
     public interface IAzureTableStorageDA
     {
-        JArray GetTableStorageItemsFromStorage(TableStorageConfiguration tableStorageConfig, string tableName, string partitionKey, bool includePartitionAndRowKeys = false);
-        List<AzureDevOpsSettings> GetAzureDevOpsSettingsFromStorage(TableStorageConfiguration tableStorageConfig, string settingsTable, string rowKey);
-        List<GitHubSettings> GetGitHubSettingsFromStorage(TableStorageConfiguration tableStorageConfig, string settingsTable, string rowKey);
+        Task<JArray> GetTableStorageItemsFromStorage(TableStorageConfiguration tableStorageConfig, string tableName, string partitionKey, bool includePartitionAndRowKeys = false);
+        Task<List<AzureDevOpsSettings>> GetAzureDevOpsSettingsFromStorage(TableStorageConfiguration tableStorageConfig, string settingsTable, string rowKey);
+        Task<List<GitHubSettings>> GetGitHubSettingsFromStorage(TableStorageConfiguration tableStorageConfig, string settingsTable, string rowKey);
         Task<int> UpdateAzureDevOpsBuildsInStorage(string patToken, TableStorageConfiguration tableStorageConfig, string organization, string project, string branch, string buildName, string buildId, int numberOfDays, int maxNumberOfItems);
         Task<int> UpdateAzureDevOpsPullRequestCommitsInStorage(string patToken, TableStorageConfiguration tableStorageConfig, string organization, string project, string repository, string pullRequestId, int numberOfDays, int maxNumberOfItems);
         Task<int> UpdateAzureDevOpsPullRequestsInStorage(string patToken, TableStorageConfiguration tableStorageConfig, string organization, string project, string repository, int numberOfDays, int maxNumberOfItems);
@@ -22,7 +22,7 @@ namespace DevOpsMetrics.Core.DataAccess.TableStorage
         Task<int> UpdateGitHubActionPullRequestsInStorage(string clientId, string clientSecret, TableStorageConfiguration tableStorageConfig, string owner, string repo, string branch, int numberOfDays, int maxNumberOfItems);
         Task<int> UpdateGitHubActionRunsInStorage(string clientId, string clientSecret, TableStorageConfiguration tableStorageConfig, string owner, string repo, string branch, string workflowName, string workflowId, int numberOfDays, int maxNumberOfItems);
         Task<bool> UpdateGitHubSettingInStorage(TableStorageConfiguration tableStorageConfig, string settingsTable, string owner, string repo, string branch, string workflowName, string workflowId, string resourceGroupName, int itemOrder, bool showSetting);
-        List<ProjectLog> GetProjectLogsFromStorage(TableStorageConfiguration tableStorageConfig, string partitionKey);
+        Task<List<ProjectLog>> GetProjectLogsFromStorage(TableStorageConfiguration tableStorageConfig, string partitionKey);
         Task<bool> UpdateProjectLogInStorage(TableStorageConfiguration tableStorageConfig, ProjectLog log);
     }
 }

--- a/src/DevOpsMetrics.Core/DataAccess/TableStorage/TableStorageCommonDA.cs
+++ b/src/DevOpsMetrics.Core/DataAccess/TableStorage/TableStorageCommonDA.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Azure.Data.Tables;
@@ -56,15 +57,10 @@ namespace DevOpsMetrics.Core.DataAccess.TableStorage
             //prepare the partition key
             partitionKey = EncodePartitionKey(partitionKey);
 
-            CloudTable table = CreateConnection();
+            TableClient tableClient = CreateConnection();
 
-            // Create a retrieve operation that takes a customer entity.
-            TableOperation retrieveOperation = TableOperation.Retrieve<AzureStorageTableModel>(partitionKey, rowKey);
-
-            // Execute the retrieve operation.
-            TableResult retrievedResult = await table.ExecuteAsync(retrieveOperation);
-
-            return (AzureStorageTableModel)retrievedResult.Result;
+            // Get the entity.
+            return await tableClient.GetEntityAsync<AzureStorageTableModel>(partitionKey, rowKey);
         }
 
         //This can't be async, because of how it queries the underlying data

--- a/src/DevOpsMetrics.Core/DataAccess/TableStorage/TableStorageCommonDA.cs
+++ b/src/DevOpsMetrics.Core/DataAccess/TableStorage/TableStorageCommonDA.cs
@@ -59,7 +59,15 @@ namespace DevOpsMetrics.Core.DataAccess.TableStorage
             TableClient tableClient = CreateConnection();
 
             // Get the entity.
-            return await tableClient.GetEntityAsync<AzureStorageTableModel>(partitionKey, rowKey);
+            NullableResponse<AzureStorageTableModel> temp = await tableClient.GetEntityIfExistsAsync<AzureStorageTableModel>(partitionKey, rowKey);
+            if (temp.HasValue)
+            {
+                return await tableClient.GetEntityAsync<AzureStorageTableModel>(partitionKey, rowKey);
+            }
+            else
+            {
+                return null;
+            }
         }
 
         //This can't be async, because of how it queries the underlying data

--- a/src/DevOpsMetrics.Core/DataAccess/TableStorage/TableStorageCommonDA.cs
+++ b/src/DevOpsMetrics.Core/DataAccess/TableStorage/TableStorageCommonDA.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Azure.Data.Tables;
 using DevOpsMetrics.Core.Models.Azure;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace DevOpsMetrics.Core.DataAccess.TableStorage
 {
@@ -109,11 +110,9 @@ namespace DevOpsMetrics.Core.DataAccess.TableStorage
 
         public async Task<bool> SaveItem(AzureStorageTableModel data)
         {
-            CloudTable table = CreateConnection();
+            TableClient tableClient = CreateConnection();
+            await tableClient.UpsertEntityAsync(data);
 
-            // Create the TableOperation that inserts/merges the entity.
-            TableOperation operation = TableOperation.InsertOrMerge(data);
-            await table.ExecuteAsync(operation);
             return true;
         }
 

--- a/src/DevOpsMetrics.Core/DataAccess/TableStorage/TableStorageCommonDA.cs
+++ b/src/DevOpsMetrics.Core/DataAccess/TableStorage/TableStorageCommonDA.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure;
 using Azure.Data.Tables;
 using DevOpsMetrics.Core.Models.Azure;
-using Microsoft.Azure.Cosmos.Table;
 
 namespace DevOpsMetrics.Core.DataAccess.TableStorage
 {
@@ -68,39 +67,10 @@ namespace DevOpsMetrics.Core.DataAccess.TableStorage
         {
             partitionKey = EncodePartitionKey(partitionKey);
 
-            CloudTable table = CreateConnection();
+            TableClient tableClient = CreateConnection();
 
-            // execute the query on the table
-            List<AzureStorageTableModel> list = table.CreateQuery<AzureStorageTableModel>()
-                                     .Where(ent => ent.PartitionKey == partitionKey)
-                                     .ToList();
-
-            //TableOperation tableOperation = TableOperation.Retrieve<AzureStorageTableModel>(partitionKey, null);
-            //TableContinuationToken Token = null;
-            //var result = table.ExecuteAsync(tableOperation);
-            //var list = new List<AzureStorageTableModel>();
-
-            //List<AzureStorageTableModel> finalResult = result.Result;
-            //return finalResult;
-
-
-            //var tableClient = Microsoft.Azure.Cosmos.Table.CloudStorageAccountExtensions.CreateCloudTableClient(storageAccount);
-            //var tableRef = tableClient.GetTableReference("UserStatuses");
-            //var query = new TableQuery<TableEntity>()
-            //                    .Where(TableQuery.GenerateFilterCondition("PartitionKey", "eq", partitionKey));
-            //var result = new List<AzureStorageTableModel>();
-
-            //var tableQuerySegment = await table.ExecuteQuerySegmentedAsync(query, null);
-            //result.AddRange(tableQuerySegment.Results);
-            //while (tableQuerySegment.ContinuationToken != null)
-            //{
-            //    tableQuerySegment = await tableRef.ExecuteQuerySegmentedAsync(query, tableQuerySegment.ContinuationToken);
-            //    result.AddRange(tableQuerySegment.Results);
-            //}
-            //return result;
-
-
-
+            AsyncPageable<AzureStorageTableModel> results = tableClient.QueryAsync<AzureStorageTableModel>(e => e.PartitionKey == partitionKey);
+            List<AzureStorageTableModel> list = await results.ToListAsync();
             return list;
         }
 

--- a/src/DevOpsMetrics.Core/DevOpsMetrics.Core.csproj
+++ b/src/DevOpsMetrics.Core/DevOpsMetrics.Core.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.8" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/DevOpsMetrics.Core/DevOpsMetrics.Core.csproj
+++ b/src/DevOpsMetrics.Core/DevOpsMetrics.Core.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Data.Tables" Version="12.8.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.8" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/DevOpsMetrics.Core/Models/Azure/AzureStorageTableModel.cs
+++ b/src/DevOpsMetrics.Core/Models/Azure/AzureStorageTableModel.cs
@@ -1,9 +1,11 @@
-﻿using DevOpsMetrics.Core.DataAccess.TableStorage;
-using Microsoft.Azure.Cosmos.Table;
+﻿using System;
+using Azure;
+using Azure.Data.Tables;
+using DevOpsMetrics.Core.DataAccess.TableStorage;
 
 namespace DevOpsMetrics.Core.Models.Azure
 {
-    public class AzureStorageTableModel : TableEntity
+    public class AzureStorageTableModel : ITableEntity
     {
         public AzureStorageTableModel(string partitionKey, string rowKey, string data)
         {
@@ -18,6 +20,22 @@ namespace DevOpsMetrics.Core.Models.Azure
         }
 
         public string Data
+        {
+            get; set;
+        }
+        public string PartitionKey
+        {
+            get; set;
+        }
+        public string RowKey
+        {
+            get; set;
+        }
+        public DateTimeOffset? Timestamp
+        {
+            get; set;
+        }
+        public ETag ETag
         {
             get; set;
         }

--- a/src/DevOpsMetrics.Service/Controllers/ChangeFailureRateController.cs
+++ b/src/DevOpsMetrics.Service/Controllers/ChangeFailureRateController.cs
@@ -18,12 +18,12 @@ namespace DevOpsMetrics.Service.Controllers
         }
 
         [HttpGet("GetChangeFailureRate")]
-        public ChangeFailureRateModel GetChangeFailureRate(bool getSampleData,
+        public async Task<ChangeFailureRateModel> GetChangeFailureRate(bool getSampleData,
             DevOpsPlatform targetDevOpsPlatform, string organization_owner, string project_repo, string branch, string buildName_workflowName,
             int numberOfDays, int maxNumberOfItems)
         {
             TableStorageConfiguration tableStorageConfig = Common.GenerateTableStorageConfiguration(Configuration);
-            ChangeFailureRateModel model = ChangeFailureRateDA.GetChangeFailureRate(getSampleData, tableStorageConfig, targetDevOpsPlatform,
+            ChangeFailureRateModel model = await ChangeFailureRateDA.GetChangeFailureRate(getSampleData, tableStorageConfig, targetDevOpsPlatform,
                 organization_owner, project_repo, branch, buildName_workflowName,
                 numberOfDays, maxNumberOfItems);
             return model;

--- a/src/DevOpsMetrics.Service/Controllers/DORASummaryController.cs
+++ b/src/DevOpsMetrics.Service/Controllers/DORASummaryController.cs
@@ -205,6 +205,7 @@ namespace DevOpsMetrics.Service.Controllers
                     }
                     else
                     {
+                        meanTimeToRestoreTask = null;
                         meanTimeToRestoreModel.MTTRAverageDurationInHours = 0;
                         meanTimeToRestoreModel.MTTRAverageDurationDescription = MeanTimeToRestore.GetMeanTimeToRestoreRating(0);
                     }

--- a/src/DevOpsMetrics.Service/Controllers/DORASummaryController.cs
+++ b/src/DevOpsMetrics.Service/Controllers/DORASummaryController.cs
@@ -25,19 +25,19 @@ namespace DevOpsMetrics.Service.Controllers
 
         // Get DORA Summary Items
         [HttpGet("GetDORASummaryItems")]
-        public List<DORASummaryItem> GetDORASummaryItems(string owner)
+        public async Task<List<DORASummaryItem>> GetDORASummaryItems(string owner)
         {
             TableStorageConfiguration tableStorageConfig = Common.GenerateTableStorageConfiguration(Configuration);
-            List<DORASummaryItem> model = DORASummaryDA.GetDORASummaryItems(tableStorageConfig, owner);
+            List<DORASummaryItem> model = await DORASummaryDA.GetDORASummaryItems(tableStorageConfig, owner);
             return model;
         }
 
         // Get DORA Summary Item
         [HttpGet("GetDORASummaryItem")]
-        public DORASummaryItem GetDORASummaryItem(string owner, string repository)
+        public async Task<DORASummaryItem> GetDORASummaryItem(string owner, string repository)
         {
             TableStorageConfiguration tableStorageConfig = Common.GenerateTableStorageConfiguration(Configuration);
-            DORASummaryItem model = DORASummaryDA.GetDORASummaryItem(tableStorageConfig, owner, repository);
+            DORASummaryItem model = await DORASummaryDA.GetDORASummaryItem(tableStorageConfig, owner, repository);
             return model;
         }
 
@@ -198,7 +198,7 @@ namespace DevOpsMetrics.Service.Controllers
                     }
                     if (resourceGroup != null)
                     {
-                        meanTimeToRestoreModel = MeanTimeToRestoreDA.GetAzureMeanTimeToRestore(false, tableStorageConfig,
+                        meanTimeToRestoreModel = await MeanTimeToRestoreDA.GetAzureMeanTimeToRestore(false, tableStorageConfig,
                             DevOpsPlatform.GitHub,
                             resourceGroup,
                             numberOfDays, maxNumberOfItems);
@@ -209,7 +209,7 @@ namespace DevOpsMetrics.Service.Controllers
                         meanTimeToRestoreModel.MTTRAverageDurationDescription = MeanTimeToRestore.GetMeanTimeToRestoreRating(0);
                     }
 
-                    changeFailureRateModel = ChangeFailureRateDA.GetChangeFailureRate(false, tableStorageConfig,
+                    changeFailureRateModel = await ChangeFailureRateDA.GetChangeFailureRate(false, tableStorageConfig,
                        DevOpsPlatform.GitHub,
                        owner, repo, branch, workflowName,
                        numberOfDays, maxNumberOfItems);
@@ -244,7 +244,7 @@ namespace DevOpsMetrics.Service.Controllers
                     }
                     if (resourceGroup != null)
                     {
-                        meanTimeToRestoreModel = MeanTimeToRestoreDA.GetAzureMeanTimeToRestore(false, tableStorageConfig,
+                        meanTimeToRestoreModel = await MeanTimeToRestoreDA.GetAzureMeanTimeToRestore(false, tableStorageConfig,
                             DevOpsPlatform.GitHub,
                             resourceGroup,
                             numberOfDays, maxNumberOfItems);
@@ -255,7 +255,7 @@ namespace DevOpsMetrics.Service.Controllers
                         meanTimeToRestoreModel.MTTRAverageDurationDescription = MeanTimeToRestore.GetMeanTimeToRestoreRating(0);
                     }
 
-                    changeFailureRateModel = ChangeFailureRateDA.GetChangeFailureRate(false, tableStorageConfig,
+                    changeFailureRateModel = await ChangeFailureRateDA.GetChangeFailureRate(false, tableStorageConfig,
                        DevOpsPlatform.GitHub,
                        owner, repo, branch, workflowName,
                        numberOfDays, maxNumberOfItems);

--- a/src/DevOpsMetrics.Service/Controllers/DORASummaryController.cs
+++ b/src/DevOpsMetrics.Service/Controllers/DORASummaryController.cs
@@ -174,8 +174,8 @@ namespace DevOpsMetrics.Service.Controllers
                 {
                     Task<DeploymentFrequencyModel> deploymentFrequencyTask;
                     Task<LeadTimeForChangesModel> leadTimeForChangesTask;
-                    MeanTimeToRestoreModel meanTimeToRestoreTask;
-                    ChangeFailureRateModel changeFailureRateTask;
+                    Task<MeanTimeToRestoreModel> meanTimeToRestoreTask;
+                    Task<ChangeFailureRateModel> changeFailureRateTask;
                     if (isGitHub == true)
                     {
                         deploymentFrequencyTask = DeploymentFrequencyDA.GetGitHubDeploymentFrequency(false, clientId, clientSecret, tableStorageConfig,
@@ -198,7 +198,7 @@ namespace DevOpsMetrics.Service.Controllers
                     }
                     if (resourceGroup != null)
                     {
-                        meanTimeToRestoreModel = await MeanTimeToRestoreDA.GetAzureMeanTimeToRestore(false, tableStorageConfig,
+                        meanTimeToRestoreTask = MeanTimeToRestoreDA.GetAzureMeanTimeToRestore(false, tableStorageConfig,
                             DevOpsPlatform.GitHub,
                             resourceGroup,
                             numberOfDays, maxNumberOfItems);
@@ -209,16 +209,16 @@ namespace DevOpsMetrics.Service.Controllers
                         meanTimeToRestoreModel.MTTRAverageDurationDescription = MeanTimeToRestore.GetMeanTimeToRestoreRating(0);
                     }
 
-                    changeFailureRateModel = await ChangeFailureRateDA.GetChangeFailureRate(false, tableStorageConfig,
+                    changeFailureRateTask = ChangeFailureRateDA.GetChangeFailureRate(false, tableStorageConfig,
                        DevOpsPlatform.GitHub,
                        owner, repo, branch, workflowName,
                        numberOfDays, maxNumberOfItems);
 
-                    await Task.WhenAll(deploymentFrequencyTask, leadTimeForChangesTask);
+                    await Task.WhenAll(deploymentFrequencyTask, leadTimeForChangesTask, meanTimeToRestoreTask, changeFailureRateTask);
                     deploymentFrequencyModel = await deploymentFrequencyTask;
                     leadTimeForChangesModel = await leadTimeForChangesTask;
-                    //meanTimeToRestoreModel = meanTimeToRestoreTask;
-                    //changeFailureRateModel = changeFailureRateTask;
+                    meanTimeToRestoreModel = await meanTimeToRestoreTask;
+                    changeFailureRateModel = await changeFailureRateTask;
                 }
                 else
                 {

--- a/src/DevOpsMetrics.Service/Controllers/DORASummaryController.cs
+++ b/src/DevOpsMetrics.Service/Controllers/DORASummaryController.cs
@@ -55,7 +55,7 @@ namespace DevOpsMetrics.Service.Controllers
             Microsoft.Extensions.Logging.ILogger log = null,
             bool useCache = true,
             bool isGitHub = true,
-            bool useParallelProcessing = false)
+            bool useParallelProcessing = true)
         {
             //Start timer
             DateTime startTime = DateTime.Now;

--- a/src/DevOpsMetrics.Service/Controllers/MeanTimeToRestoreController.cs
+++ b/src/DevOpsMetrics.Service/Controllers/MeanTimeToRestoreController.cs
@@ -1,4 +1,5 @@
-﻿using DevOpsMetrics.Core.DataAccess;
+﻿using System.Threading.Tasks;
+using DevOpsMetrics.Core.DataAccess;
 using DevOpsMetrics.Core.Models.Common;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
@@ -17,12 +18,12 @@ namespace DevOpsMetrics.Service.Controllers
         }
 
         [HttpGet("GetAzureMeanTimeToRestore")]
-        public MeanTimeToRestoreModel GetAzureMeanTimeToRestore(bool getSampleData,
+        public async Task<MeanTimeToRestoreModel> GetAzureMeanTimeToRestore(bool getSampleData,
             DevOpsPlatform targetDevOpsPlatform, string resourceGroup,
             int numberOfDays, int maxNumberOfItems)
         {
             TableStorageConfiguration tableStorageConfig = Common.GenerateTableStorageConfiguration(Configuration);
-            MeanTimeToRestoreModel model = MeanTimeToRestoreDA.GetAzureMeanTimeToRestore(getSampleData, tableStorageConfig,
+            MeanTimeToRestoreModel model = await MeanTimeToRestoreDA.GetAzureMeanTimeToRestore(getSampleData, tableStorageConfig,
                 targetDevOpsPlatform, resourceGroup,
                 numberOfDays, maxNumberOfItems);
             return model;

--- a/src/DevOpsMetrics.Service/Controllers/SettingsController.cs
+++ b/src/DevOpsMetrics.Service/Controllers/SettingsController.cs
@@ -119,12 +119,12 @@ namespace DevOpsMetrics.Service.Controllers
         }
 
         [HttpGet("GetGitHubProjectLog")]
-        public List<ProjectLog> GetGitHubProjectLog(string owner, string repo)
+        public async Task< List<ProjectLog>> GetGitHubProjectLog(string owner, string repo)
         {
             string partitionKey = PartitionKeys.CreateGitHubSettingsPartitionKey(owner, repo);
 
             TableStorageConfiguration tableStorageConfig = Common.GenerateTableStorageConfiguration(Configuration);
-            return AzureTableStorageDA.GetProjectLogsFromStorage(tableStorageConfig, partitionKey);
+            return await AzureTableStorageDA.GetProjectLogsFromStorage(tableStorageConfig, partitionKey);
         }
 
         [HttpGet("UpdateGitHubProjectLog")]

--- a/src/DevOpsMetrics.Service/Controllers/SettingsController.cs
+++ b/src/DevOpsMetrics.Service/Controllers/SettingsController.cs
@@ -28,18 +28,18 @@ namespace DevOpsMetrics.Service.Controllers
         }
 
         [HttpGet("GetAzureDevOpsSettings")]
-        public List<AzureDevOpsSettings> GetAzureDevOpsSettings(string rowKey = null)
+        public async Task<List<AzureDevOpsSettings>> GetAzureDevOpsSettings(string rowKey = null)
         {
             TableStorageConfiguration tableStorageConfig = Common.GenerateTableStorageConfiguration(Configuration);
-            List<AzureDevOpsSettings> settings = AzureTableStorageDA.GetAzureDevOpsSettingsFromStorage(tableStorageConfig, tableStorageConfig.TableAzureDevOpsSettings, rowKey);
+            List<AzureDevOpsSettings> settings = await AzureTableStorageDA.GetAzureDevOpsSettingsFromStorage(tableStorageConfig, tableStorageConfig.TableAzureDevOpsSettings, rowKey);
             return settings;
         }
 
         [HttpGet("GetGitHubSettings")]
-        public List<GitHubSettings> GetGitHubSettings(string rowKey = null)
+        public async Task<List<GitHubSettings>> GetGitHubSettings(string rowKey = null)
         {
             TableStorageConfiguration tableStorageConfig = Common.GenerateTableStorageConfiguration(Configuration);
-            List<GitHubSettings> settings = AzureTableStorageDA.GetGitHubSettingsFromStorage(tableStorageConfig, tableStorageConfig.TableGitHubSettings, rowKey);
+            List<GitHubSettings> settings = await AzureTableStorageDA.GetGitHubSettingsFromStorage(tableStorageConfig, tableStorageConfig.TableGitHubSettings, rowKey);
             return settings;
         }
 
@@ -97,12 +97,12 @@ namespace DevOpsMetrics.Service.Controllers
         }
 
         [HttpGet("GetAzureDevOpsProjectLog")]
-        public List<ProjectLog> GetAzureDevOpsProjectLog(string organization, string project, string repository)
+        public async Task<List<ProjectLog>> GetAzureDevOpsProjectLog(string organization, string project, string repository)
         {
             string partitionKey = PartitionKeys.CreateAzureDevOpsSettingsPartitionKey(organization, project, repository);
 
             TableStorageConfiguration tableStorageConfig = Common.GenerateTableStorageConfiguration(Configuration);
-            return AzureTableStorageDA.GetProjectLogsFromStorage(tableStorageConfig, partitionKey);
+            return await AzureTableStorageDA.GetProjectLogsFromStorage(tableStorageConfig, partitionKey);
         }
 
         [HttpGet("UpdateAzureDevOpsProjectLog")]

--- a/src/DevOpsMetrics.Tests/Core/ChangeFailureRateDATests.cs
+++ b/src/DevOpsMetrics.Tests/Core/ChangeFailureRateDATests.cs
@@ -14,7 +14,7 @@ namespace DevOpsMetrics.Tests.Core
 
         [TestCategory("UnitTest")]
         [TestMethod]
-        public void AzChangeFailureRateDAIntegrationTest()
+        public async Task AzChangeFailureRateDAIntegrationTest()
         {
             //Arrange
             bool getSampleData = true;
@@ -28,7 +28,7 @@ namespace DevOpsMetrics.Tests.Core
             int maxNumberOfItems = 20;
 
             //Act
-            ChangeFailureRateModel model = ChangeFailureRateDA.GetChangeFailureRate(getSampleData, tableStorageConfig,
+            ChangeFailureRateModel model = await ChangeFailureRateDA.GetChangeFailureRate(getSampleData, tableStorageConfig,
                targetDevOpsPlatform, organization, project, branch, buildName, numberOfDays, maxNumberOfItems);
 
             //Assert
@@ -77,7 +77,7 @@ namespace DevOpsMetrics.Tests.Core
 
         [TestCategory("UnitTest")]
         [TestMethod]
-        public void GHChangeFailureRateDAIntegrationTest()
+        public async Task GHChangeFailureRateDAIntegrationTest()
         {
             //Arrange
             bool getSampleData = true;
@@ -91,7 +91,7 @@ namespace DevOpsMetrics.Tests.Core
             int maxNumberOfItems = 20;
 
             //Act
-            ChangeFailureRateModel model = ChangeFailureRateDA.GetChangeFailureRate(getSampleData, tableStorageConfig,
+            ChangeFailureRateModel model = await ChangeFailureRateDA.GetChangeFailureRate(getSampleData, tableStorageConfig,
                targetDevOpsPlatform, owner, repo, branch, workflowName, numberOfDays, maxNumberOfItems);
 
             //Assert

--- a/src/DevOpsMetrics.Tests/Core/MeanTimeToRestoreDATests.cs
+++ b/src/DevOpsMetrics.Tests/Core/MeanTimeToRestoreDATests.cs
@@ -38,7 +38,7 @@ namespace DevOpsMetrics.Tests.Core
         }
 
         [TestMethod]
-        public void MeanTimeToRestoreDADevOpsMetricsProdIntegrationTest()
+        public async Task MeanTimeToRestoreDADevOpsMetricsProdIntegrationTest()
         {
             //Arrange
             bool getSampleData = false;
@@ -49,7 +49,7 @@ namespace DevOpsMetrics.Tests.Core
             int maxNumberOfItems = 20;
 
             //Act
-            MeanTimeToRestoreModel model = MeanTimeToRestoreDA.GetAzureMeanTimeToRestore(getSampleData, tableStorageConfig, targetDevOpsPlatform, resourceGroup, numberOfDays, maxNumberOfItems);
+            MeanTimeToRestoreModel model = await MeanTimeToRestoreDA.GetAzureMeanTimeToRestore(getSampleData, tableStorageConfig, targetDevOpsPlatform, resourceGroup, numberOfDays, maxNumberOfItems);
 
             //Assert
             Assert.IsTrue(model != null);
@@ -64,7 +64,7 @@ namespace DevOpsMetrics.Tests.Core
 
 
         [TestMethod]
-        public void TimeToRestoreServiceDAIntegrationTest()
+        public async Task TimeToRestoreServiceDAIntegrationTest()
         {
             //Arrange
             bool getSampleData = false;
@@ -75,7 +75,7 @@ namespace DevOpsMetrics.Tests.Core
             int maxNumberOfItems = 20;
 
             //Act
-            MeanTimeToRestoreModel model = MeanTimeToRestoreDA.GetAzureMeanTimeToRestore(getSampleData, tableStorageConfig, targetDevOpsPlatform, resourceGroup, numberOfDays, maxNumberOfItems);
+            MeanTimeToRestoreModel model = await MeanTimeToRestoreDA.GetAzureMeanTimeToRestore(getSampleData, tableStorageConfig, targetDevOpsPlatform, resourceGroup, numberOfDays, maxNumberOfItems);
 
             //Assert
             Assert.IsTrue(model != null);
@@ -90,7 +90,7 @@ namespace DevOpsMetrics.Tests.Core
         }
 
         [TestMethod]
-        public void TimeToRestoreServiceDALiveIntegrationTest()
+        public async Task TimeToRestoreServiceDALiveIntegrationTest()
         {
             //Arrange
             bool getSampleData = false;
@@ -101,7 +101,7 @@ namespace DevOpsMetrics.Tests.Core
             int maxNumberOfItems = 20;
 
             //Act
-            MeanTimeToRestoreModel model = MeanTimeToRestoreDA.GetAzureMeanTimeToRestore(getSampleData, tableStorageConfig, targetDevOpsPlatform, resourceGroup, numberOfDays, maxNumberOfItems);
+            MeanTimeToRestoreModel model = await MeanTimeToRestoreDA.GetAzureMeanTimeToRestore(getSampleData, tableStorageConfig, targetDevOpsPlatform, resourceGroup, numberOfDays, maxNumberOfItems);
 
             //Assert
             Assert.IsTrue(model != null);

--- a/src/DevOpsMetrics.Tests/Core/MeanTimeToRestoreDATests.cs
+++ b/src/DevOpsMetrics.Tests/Core/MeanTimeToRestoreDATests.cs
@@ -1,4 +1,5 @@
-﻿using DevOpsMetrics.Core.DataAccess;
+﻿using System.Threading.Tasks;
+using DevOpsMetrics.Core.DataAccess;
 using DevOpsMetrics.Core.Models.Common;
 using DevOpsMetrics.Service;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -12,7 +13,7 @@ namespace DevOpsMetrics.Tests.Core
     {
         [TestCategory("UnitTest")]
         [TestMethod]
-        public void MeanTimeToRestoreDAIntegrationTest()
+        public async Task MeanTimeToRestoreDAIntegrationTest()
         {
             //Arrange
             bool getSampleData = true;
@@ -23,7 +24,7 @@ namespace DevOpsMetrics.Tests.Core
             int maxNumberOfItems = 20;
 
             //Act
-            MeanTimeToRestoreModel model = MeanTimeToRestoreDA.GetAzureMeanTimeToRestore(getSampleData, tableStorageConfig, targetDevOpsPlatform, resourceGroup, numberOfDays, maxNumberOfItems);
+            MeanTimeToRestoreModel model = await MeanTimeToRestoreDA.GetAzureMeanTimeToRestore(getSampleData, tableStorageConfig, targetDevOpsPlatform, resourceGroup, numberOfDays, maxNumberOfItems);
 
             //Assert
             Assert.IsTrue(model != null);

--- a/src/DevOpsMetrics.Tests/Core/SettingsDATests.cs
+++ b/src/DevOpsMetrics.Tests/Core/SettingsDATests.cs
@@ -33,21 +33,21 @@ namespace DevOpsMetrics.Tests.Core
         }
 
         [TestMethod]
-        public void AzGetAzDoDevOpsMetricsSettingDAIntegrationTest()
+        public async Task AzGetAzDoDevOpsMetricsSettingDAIntegrationTest()
         {
             //Arrange
             TableStorageConfiguration tableStorageConfig = Common.GenerateTableStorageConfiguration(base.Configuration);
 
             //Act
             AzureTableStorageDA da = new();
-            List<AzureDevOpsSettings> results = da.GetAzureDevOpsSettingsFromStorage(tableStorageConfig, tableStorageConfig.TableAzureDevOpsSettings, null);
+            List<AzureDevOpsSettings> results = await da.GetAzureDevOpsSettingsFromStorage(tableStorageConfig, tableStorageConfig.TableAzureDevOpsSettings, null);
 
             //Assert
             Assert.IsTrue(results.Count > 0);
         }
 
         [TestMethod]
-        public void GHGetSettingDAIntegrationTest()
+        public async Task GHGetSettingDAIntegrationTest()
         {
 
             //Arrange
@@ -55,7 +55,7 @@ namespace DevOpsMetrics.Tests.Core
 
             //Act
             AzureTableStorageDA da = new();
-            List<GitHubSettings> results = da.GetGitHubSettingsFromStorage(tableStorageConfig, tableStorageConfig.TableGitHubSettings, null);
+            List<GitHubSettings> results = await da.GetGitHubSettingsFromStorage(tableStorageConfig, tableStorageConfig.TableGitHubSettings, null);
 
             //Assert
             Assert.IsTrue(results.Count > 0);

--- a/src/DevOpsMetrics.Tests/Service/ChangeFailureRateControllerTests.cs
+++ b/src/DevOpsMetrics.Tests/Service/ChangeFailureRateControllerTests.cs
@@ -1,4 +1,5 @@
-﻿using DevOpsMetrics.Core.Models.Common;
+﻿using System.Threading.Tasks;
+using DevOpsMetrics.Core.Models.Common;
 using DevOpsMetrics.Service.Controllers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -10,7 +11,7 @@ namespace DevOpsMetrics.Tests.Service
     public class ChangeFailureRateControllerTests : BaseConfiguration
     {
         [TestMethod]
-        public void AzChangeFailureRateSampleControllerIntegrationTest()
+        public async Task AzChangeFailureRateSampleControllerIntegrationTest()
         {
             //Arrange
             bool getSampleData = true;
@@ -24,7 +25,7 @@ namespace DevOpsMetrics.Tests.Service
             ChangeFailureRateController controller = new(base.Configuration);
 
             //Act
-            ChangeFailureRateModel model = controller.GetChangeFailureRate(getSampleData,
+            ChangeFailureRateModel model = await controller.GetChangeFailureRate(getSampleData,
                 targetDevOpsPlatform, organization, project, branch, buildName, numberOfDays, maxNumberOfItems);
 
             //Assert
@@ -70,7 +71,7 @@ namespace DevOpsMetrics.Tests.Service
         //}
 
         [TestMethod]
-        public void GHChangeFailureRateSampleControllerIntegrationTest()
+        public async Task GHChangeFailureRateSampleControllerIntegrationTest()
         {
             //Arrange
             bool getSampleData = true;
@@ -88,7 +89,7 @@ namespace DevOpsMetrics.Tests.Service
             ChangeFailureRateController controller = new(base.Configuration);
 
             //Act
-            ChangeFailureRateModel model = controller.GetChangeFailureRate(getSampleData,
+            ChangeFailureRateModel model = await controller.GetChangeFailureRate(getSampleData,
                targetDevOpsPlatform, owner, repo, branch, workflowName, numberOfDays, maxNumberOfItems);
 
             //Assert
@@ -105,7 +106,7 @@ namespace DevOpsMetrics.Tests.Service
 
         [TestCategory("IntegrationTest")]
         [TestMethod]
-        public void GHChangeFailureRateLiveControllerIntegrationTest()
+        public async Task GHChangeFailureRateLiveControllerIntegrationTest()
         {
             //Arrange
             bool getSampleData = false;
@@ -119,7 +120,7 @@ namespace DevOpsMetrics.Tests.Service
             ChangeFailureRateController controller = new(base.Configuration);
 
             //Act
-            ChangeFailureRateModel model = controller.GetChangeFailureRate(getSampleData,
+            ChangeFailureRateModel model = await controller.GetChangeFailureRate(getSampleData,
                targetDevOpsPlatform, owner, repo, branch, workflowName, numberOfDays, maxNumberOfItems);
 
             //Assert

--- a/src/DevOpsMetrics.Tests/Service/DORASummaryControllerTests.cs
+++ b/src/DevOpsMetrics.Tests/Service/DORASummaryControllerTests.cs
@@ -126,8 +126,8 @@ namespace DevOpsMetrics.Tests.Service
             //Act
             if (runExpensiveTest)
             {
-                List<AzureDevOpsSettings> azSettings = settingsController.GetAzureDevOpsSettings();
-                List<GitHubSettings> ghSettings = settingsController.GetGitHubSettings();
+                List<AzureDevOpsSettings> azSettings = await settingsController.GetAzureDevOpsSettings();
+                List<GitHubSettings> ghSettings = await settingsController.GetGitHubSettings();
 
                 foreach (AzureDevOpsSettings azSetting in azSettings)
                 {

--- a/src/DevOpsMetrics.Tests/Service/DORASummaryControllerTests.cs
+++ b/src/DevOpsMetrics.Tests/Service/DORASummaryControllerTests.cs
@@ -16,7 +16,7 @@ namespace DevOpsMetrics.Tests.Service
     public class DORASummaryControllerTests : BaseConfiguration
     {
         [TestMethod]
-        public void DORASummaryControllerGetIntegrationTest()
+        public async Task DORASummaryControllerGetIntegrationTest()
         {
             //Arrange
             string organization = "DeveloperMetrics";
@@ -24,14 +24,14 @@ namespace DevOpsMetrics.Tests.Service
             DORASummaryController controller = new(base.Configuration);
 
             //Act
-            DORASummaryItem model = controller.GetDORASummaryItem(organization, repository);
+            DORASummaryItem model = await controller.GetDORASummaryItem(organization, repository);
 
             //Assert
             Assert.IsNotNull(model);
 
         }
         [TestMethod]
-        public void DORASummaryControllerGetIntegrationTest2()
+        public async Task DORASummaryControllerGetIntegrationTest2()
         {
             //Arrange
             string organization = "samsmithnz";
@@ -39,7 +39,7 @@ namespace DevOpsMetrics.Tests.Service
             DORASummaryController controller = new(base.Configuration);
 
             //Act
-            DORASummaryItem model = controller.GetDORASummaryItem(organization, repository);
+            DORASummaryItem model = await controller.GetDORASummaryItem(organization, repository);
 
             //Assert
             Assert.IsNotNull(model);
@@ -77,7 +77,7 @@ namespace DevOpsMetrics.Tests.Service
                 branch, workflowName, workflowId, resourceGroup, numberOfDays, maxNumberOfItems,
                 null, true, true);
 
-            DORASummaryItem doraSummaryItem = controller.GetDORASummaryItem(organization, repository);
+            DORASummaryItem doraSummaryItem = awaitcontroller.GetDORASummaryItem(organization, repository);
 
             //Assert
             Assert.IsNotNull(model);

--- a/src/DevOpsMetrics.Tests/Service/DORASummaryControllerTests.cs
+++ b/src/DevOpsMetrics.Tests/Service/DORASummaryControllerTests.cs
@@ -77,7 +77,7 @@ namespace DevOpsMetrics.Tests.Service
                 branch, workflowName, workflowId, resourceGroup, numberOfDays, maxNumberOfItems,
                 null, true, true);
 
-            DORASummaryItem doraSummaryItem = awaitcontroller.GetDORASummaryItem(organization, repository);
+            DORASummaryItem doraSummaryItem = await controller.GetDORASummaryItem(organization, repository);
 
             //Assert
             Assert.IsNotNull(model);

--- a/src/DevOpsMetrics.Tests/Service/MeanTimeToRestoreControllerTests.cs
+++ b/src/DevOpsMetrics.Tests/Service/MeanTimeToRestoreControllerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using DevOpsMetrics.Core.Models.Common;
 using DevOpsMetrics.Service.Controllers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -12,7 +13,7 @@ namespace DevOpsMetrics.Tests.Service
     {
         [TestCategory("UnitTest")]
         [TestMethod]
-        public void AzureMTTRSampleControllerIntegrationTest()
+        public async Task AzureMTTRSampleControllerIntegrationTest()
         {
             //Arrange
             bool getSampleData = true;
@@ -23,7 +24,7 @@ namespace DevOpsMetrics.Tests.Service
             MeanTimeToRestoreController controller = new(base.Configuration);
 
             //Act
-            MeanTimeToRestoreModel model = controller.GetAzureMeanTimeToRestore(getSampleData, targetDevOpsPlatform, resourceGroupName, numberOfDays, maxNumberOfItems);
+            MeanTimeToRestoreModel model = await controller.GetAzureMeanTimeToRestore(getSampleData, targetDevOpsPlatform, resourceGroupName, numberOfDays, maxNumberOfItems);
 
             //Assert
             Assert.IsTrue(model != null);
@@ -46,7 +47,7 @@ namespace DevOpsMetrics.Tests.Service
         }
 
         [TestMethod]
-        public void AzureMTTRsAPIControllerIntegrationTest()
+        public async Task AzureMTTRsAPIControllerIntegrationTest()
         {
             //Arrange
             bool getSampleData = false;
@@ -57,7 +58,7 @@ namespace DevOpsMetrics.Tests.Service
             MeanTimeToRestoreController controller = new(base.Configuration);
 
             //Act
-            MeanTimeToRestoreModel model = controller.GetAzureMeanTimeToRestore(getSampleData, targetDevOpsPlatform, resourceGroupName, numberOfDays, maxNumberOfItems);
+            MeanTimeToRestoreModel model = await controller.GetAzureMeanTimeToRestore(getSampleData, targetDevOpsPlatform, resourceGroupName, numberOfDays, maxNumberOfItems);
 
             //Assert
             Assert.IsTrue(model != null);
@@ -83,7 +84,7 @@ namespace DevOpsMetrics.Tests.Service
         }
 
         [TestMethod]
-        public void AzureMTTRsAPINullIntegrationTest()
+        public async Task AzureMTTRsAPINullIntegrationTest()
         {
             //Arrange
             bool getSampleData = false;
@@ -94,7 +95,7 @@ namespace DevOpsMetrics.Tests.Service
             MeanTimeToRestoreController controller = new(base.Configuration);
 
             //Act
-            MeanTimeToRestoreModel model = controller.GetAzureMeanTimeToRestore(getSampleData, targetDevOpsPlatform, resourceGroupName, numberOfDays, maxNumberOfItems);
+            MeanTimeToRestoreModel model = await controller.GetAzureMeanTimeToRestore(getSampleData, targetDevOpsPlatform, resourceGroupName, numberOfDays, maxNumberOfItems);
 
             //Assert
             Assert.IsTrue(model != null);
@@ -120,7 +121,7 @@ namespace DevOpsMetrics.Tests.Service
         }
 
         [TestMethod]
-        public void AzureMTTRsAPIEmptyIntegrationTest()
+        public async Task AzureMTTRsAPIEmptyIntegrationTest()
         {
             //Arrange
             bool getSampleData = false;
@@ -131,7 +132,7 @@ namespace DevOpsMetrics.Tests.Service
             MeanTimeToRestoreController controller = new(base.Configuration);
 
             //Act
-            MeanTimeToRestoreModel model = controller.GetAzureMeanTimeToRestore(getSampleData, targetDevOpsPlatform, resourceGroupName, numberOfDays, maxNumberOfItems);
+            MeanTimeToRestoreModel model = await controller.GetAzureMeanTimeToRestore(getSampleData, targetDevOpsPlatform, resourceGroupName, numberOfDays, maxNumberOfItems);
 
             //Assert
             Assert.IsTrue(model != null);

--- a/src/DevOpsMetrics.Tests/Service/TableStorageControllerDATests.cs
+++ b/src/DevOpsMetrics.Tests/Service/TableStorageControllerDATests.cs
@@ -53,7 +53,7 @@ namespace DevOpsMetrics.Tests.Service
             //Arrange
             Mock<IAzureTableStorageDA> mockDA = new();
             mockDA.Setup(repo => repo.UpdateAzureDevOpsBuildsInStorage(It.IsAny<string>(), It.IsAny<TableStorageConfiguration>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>())).Returns(Task.FromResult(GetSampleUpdateData()));
-            mockDA.Setup(repo => repo.GetAzureDevOpsSettingsFromStorage(It.IsAny<TableStorageConfiguration>(), It.IsAny<string>(), It.IsAny<string>())).Returns(new List<AzureDevOpsSettings> { new AzureDevOpsSettings() });
+            mockDA.Setup(repo => repo.GetAzureDevOpsSettingsFromStorage(It.IsAny<TableStorageConfiguration>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(new List<AzureDevOpsSettings> { new AzureDevOpsSettings() }));
             BuildsController controller = new(_configuration, mockDA.Object);
             string organization = "";
             string project = "";
@@ -77,7 +77,7 @@ namespace DevOpsMetrics.Tests.Service
             //Arrange
             Mock<IAzureTableStorageDA> mockDA = new();
             mockDA.Setup(repo => repo.UpdateGitHubActionRunsInStorage(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TableStorageConfiguration>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>())).Returns(Task.FromResult(GetSampleUpdateData()));
-            mockDA.Setup(repo => repo.GetGitHubSettingsFromStorage(It.IsAny<TableStorageConfiguration>(), It.IsAny<string>(), It.IsAny<string>())).Returns(new List<GitHubSettings> { new GitHubSettings() });
+            mockDA.Setup(repo => repo.GetGitHubSettingsFromStorage(It.IsAny<TableStorageConfiguration>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(new List<GitHubSettings> { new GitHubSettings() }));
             BuildsController controller = new(_configuration, mockDA.Object);
             string owner = "";
             string repo = "";
@@ -100,7 +100,7 @@ namespace DevOpsMetrics.Tests.Service
             //Arrange
             Mock<IAzureTableStorageDA> mockDA = new();
             mockDA.Setup(repo => repo.UpdateAzureDevOpsPullRequestsInStorage(It.IsAny<string>(), It.IsAny<TableStorageConfiguration>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>())).Returns(Task.FromResult(GetSampleUpdateData()));
-            mockDA.Setup(repo => repo.GetAzureDevOpsSettingsFromStorage(It.IsAny<TableStorageConfiguration>(), It.IsAny<string>(), It.IsAny<string>())).Returns(new List<AzureDevOpsSettings> { new AzureDevOpsSettings() });
+            mockDA.Setup(repo => repo.GetAzureDevOpsSettingsFromStorage(It.IsAny<TableStorageConfiguration>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(new List<AzureDevOpsSettings> { new AzureDevOpsSettings() }));
             PullRequestsController controller = new(_configuration, mockDA.Object);
             string organization = "";
             string project = "";
@@ -121,7 +121,7 @@ namespace DevOpsMetrics.Tests.Service
             //Arrange
             Mock<IAzureTableStorageDA> mockDA = new();
             mockDA.Setup(repo => repo.UpdateGitHubActionPullRequestsInStorage(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TableStorageConfiguration>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>())).Returns(Task.FromResult(GetSampleUpdateData()));
-            mockDA.Setup(repo => repo.GetGitHubSettingsFromStorage(It.IsAny<TableStorageConfiguration>(), It.IsAny<string>(), It.IsAny<string>())).Returns(new List<GitHubSettings> { new GitHubSettings() });
+            mockDA.Setup(repo => repo.GetGitHubSettingsFromStorage(It.IsAny<TableStorageConfiguration>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(new List<GitHubSettings> { new GitHubSettings() }));
             PullRequestsController controller = new(_configuration, mockDA.Object);
             string owner = "";
             string repo = "";
@@ -142,7 +142,7 @@ namespace DevOpsMetrics.Tests.Service
             //Arrange
             Mock<IAzureTableStorageDA> mockDA = new();
             mockDA.Setup(repo => repo.UpdateAzureDevOpsPullRequestCommitsInStorage(It.IsAny<string>(), It.IsAny<TableStorageConfiguration>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>())).Returns(Task.FromResult(GetSampleUpdateData()));
-            mockDA.Setup(repo => repo.GetAzureDevOpsSettingsFromStorage(It.IsAny<TableStorageConfiguration>(), It.IsAny<string>(), It.IsAny<string>())).Returns(new List<AzureDevOpsSettings> { new AzureDevOpsSettings() });
+            mockDA.Setup(repo => repo.GetAzureDevOpsSettingsFromStorage(It.IsAny<TableStorageConfiguration>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(new List<AzureDevOpsSettings> { new AzureDevOpsSettings() }));
             PullRequestsController controller = new(_configuration, mockDA.Object);
             string organization = "";
             string project = "";
@@ -164,7 +164,7 @@ namespace DevOpsMetrics.Tests.Service
             //Arrange
             Mock<IAzureTableStorageDA> mockDA = new();
             mockDA.Setup(repo => repo.UpdateGitHubActionPullRequestCommitsInStorage(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TableStorageConfiguration>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(GetSampleUpdateData()));
-            mockDA.Setup(repo => repo.GetGitHubSettingsFromStorage(It.IsAny<TableStorageConfiguration>(), It.IsAny<string>(), It.IsAny<string>())).Returns(new List<GitHubSettings> { new GitHubSettings() });
+            mockDA.Setup(repo => repo.GetGitHubSettingsFromStorage(It.IsAny<TableStorageConfiguration>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(new List<GitHubSettings> { new GitHubSettings() }));
             PullRequestsController controller = new(_configuration, mockDA.Object);
             string owner = "";
             string repo = "";
@@ -179,30 +179,30 @@ namespace DevOpsMetrics.Tests.Service
 
 
         [TestMethod]
-        public void GetAzureDevOpsSettingsTest()
+        public async Task GetAzureDevOpsSettingsTest()
         {
             //Arrange
             Mock<IAzureTableStorageDA> mockDA = new();
-            mockDA.Setup(repo => repo.GetAzureDevOpsSettingsFromStorage(It.IsAny<TableStorageConfiguration>(), It.IsAny<string>(), null)).Returns(GetSampleAzureDevOpsSettingsData());
+            mockDA.Setup(repo => repo.GetAzureDevOpsSettingsFromStorage(It.IsAny<TableStorageConfiguration>(), It.IsAny<string>(), null)).Returns(Task.FromResult(GetSampleAzureDevOpsSettingsData()));
             SettingsController controller = new(_configuration, mockDA.Object);
 
             //Act
-            List<AzureDevOpsSettings> result = controller.GetAzureDevOpsSettings();
+            List<AzureDevOpsSettings> result = await controller.GetAzureDevOpsSettings();
 
             //Assert
             Assert.IsTrue(result != null);
         }
 
         [TestMethod]
-        public void GetGitHubSettingsTest()
+        public async Task GetGitHubSettingsTest()
         {
             //Arrange
             Mock<IAzureTableStorageDA> mockDA = new();
-            mockDA.Setup(repo => repo.GetGitHubSettingsFromStorage(It.IsAny<TableStorageConfiguration>(), It.IsAny<string>(), It.IsAny<string>())).Returns(GetSampleGitHubSettingsData());
+            mockDA.Setup(repo => repo.GetGitHubSettingsFromStorage(It.IsAny<TableStorageConfiguration>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(GetSampleGitHubSettingsData()));
             SettingsController controller = new(_configuration, mockDA.Object);
 
             //Act
-            List<GitHubSettings> result = controller.GetGitHubSettings();
+            List<GitHubSettings> result = await controller.GetGitHubSettings();
 
             //Assert
             Assert.IsTrue(result != null);
@@ -276,18 +276,18 @@ namespace DevOpsMetrics.Tests.Service
         }
 
         [TestMethod]
-        public void GetAzureDevOpsLogTest()
+        public async Task GetAzureDevOpsLogTest()
         {
             //Arrange
             Mock<IAzureTableStorageDA> mockDA = new();
-            mockDA.Setup(repo => repo.GetProjectLogsFromStorage(It.IsAny<TableStorageConfiguration>(), It.IsAny<string>())).Returns(new List<ProjectLog> { new ProjectLog() });
+            mockDA.Setup(repo => repo.GetProjectLogsFromStorage(It.IsAny<TableStorageConfiguration>(), It.IsAny<string>())).Returns(Task.FromResult(new List<ProjectLog> { new ProjectLog() }));
             SettingsController controller = new(_configuration, mockDA.Object);
             string organization = "TestOrg";
             string project = "TestProject";
             string repository = "TestRepo";
 
             //Act
-            List<ProjectLog> results = controller.GetAzureDevOpsProjectLog(organization, project, repository);
+            List<ProjectLog> results = await controller.GetAzureDevOpsProjectLog(organization, project, repository);
 
             //Assert
             Assert.IsTrue(results != null);
@@ -321,18 +321,18 @@ namespace DevOpsMetrics.Tests.Service
         }
 
         [TestMethod]
-        public void GetGitHubLogTest()
+        public async Task GetGitHubLogTest()
         {
             //Arrange
             //Mock<IConfiguration> mockConfig = new Mock<IConfiguration>();
             Mock<IAzureTableStorageDA> mockDA = new();
-            mockDA.Setup(repo => repo.GetProjectLogsFromStorage(It.IsAny<TableStorageConfiguration>(), It.IsAny<string>())).Returns(new List<ProjectLog> { new ProjectLog() });
+            mockDA.Setup(repo => repo.GetProjectLogsFromStorage(It.IsAny<TableStorageConfiguration>(), It.IsAny<string>())).Returns(Task.FromResult(new List<ProjectLog> { new ProjectLog() }));
             SettingsController controller = new(_configuration, mockDA.Object);
             string owner = "TestOrg";
             string repo = "TestRepo";
 
             //Act
-            List<ProjectLog> results = controller.GetGitHubProjectLog(owner, repo);
+            List<ProjectLog> results = await controller.GetGitHubProjectLog(owner, repo);
 
             //Assert
             Assert.IsTrue(results != null);

--- a/src/DevOpsMetrics.Tests/Service/TableStorageDATests.cs
+++ b/src/DevOpsMetrics.Tests/Service/TableStorageDATests.cs
@@ -16,7 +16,7 @@ namespace DevOpsMetrics.Tests.Service
     public class TableStorageDATests : BaseConfiguration
     {
         [TestMethod]
-        public void AzGetBuildsDAIntegrationTest()
+        public async Task AzGetBuildsDAIntegrationTest()
         {
             //Arrange
             TableStorageConfiguration tableStorageConfig = Common.GenerateTableStorageConfiguration(base.Configuration);
@@ -26,7 +26,7 @@ namespace DevOpsMetrics.Tests.Service
 
             //Act
             AzureTableStorageDA da = new();
-            JArray list = da.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableAzureDevOpsBuilds, PartitionKeys.CreateBuildWorkflowPartitionKey(organization, project, buildName));
+            JArray list = await da.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableAzureDevOpsBuilds, PartitionKeys.CreateBuildWorkflowPartitionKey(organization, project, buildName));
 
             //Assert
             Assert.IsTrue(list.Count >= 0);
@@ -55,7 +55,7 @@ namespace DevOpsMetrics.Tests.Service
         }
 
         [TestMethod]
-        public void AzGetPRsDAIntegrationTest()
+        public async Task AzGetPRsDAIntegrationTest()
         {
             //Arrange
             TableStorageConfiguration tableStorageConfig = Common.GenerateTableStorageConfiguration(base.Configuration);
@@ -64,7 +64,7 @@ namespace DevOpsMetrics.Tests.Service
 
             //Act
             AzureTableStorageDA da = new();
-            JArray list = da.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableAzureDevOpsBuilds, PartitionKeys.CreateAzureDevOpsPRPartitionKey(organization, project));
+            JArray list = await da.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableAzureDevOpsBuilds, PartitionKeys.CreateAzureDevOpsPRPartitionKey(organization, project));
 
             //Assert
             Assert.IsTrue(list.Count >= 0);
@@ -92,7 +92,7 @@ namespace DevOpsMetrics.Tests.Service
         }
 
         [TestMethod]
-        public void AzGetPRCommitsDAIntegrationTest()
+        public async Task AzGetPRCommitsDAIntegrationTest()
         {
             //Arrange
             TableStorageConfiguration tableStorageConfig = Common.GenerateTableStorageConfiguration(base.Configuration);
@@ -101,13 +101,13 @@ namespace DevOpsMetrics.Tests.Service
 
             //Act
             AzureTableStorageDA da = new();
-            JArray prList = da.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableAzureDevOpsPRs, PartitionKeys.CreateAzureDevOpsPRPartitionKey(organization, project));
+            JArray prList = await da.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableAzureDevOpsPRs, PartitionKeys.CreateAzureDevOpsPRPartitionKey(organization, project));
             int itemsAdded = 0;
             foreach (JToken item in prList)
             {
                 AzureDevOpsPR pullRequest = JsonConvert.DeserializeObject<AzureDevOpsPR>(item.ToString());
                 string pullRequestId = pullRequest.PullRequestId;
-                JArray list = da.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableAzureDevOpsPRCommits, PartitionKeys.CreateAzureDevOpsPRCommitPartitionKey(organization, project, pullRequestId));
+                JArray list =await da.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableAzureDevOpsPRCommits, PartitionKeys.CreateAzureDevOpsPRCommitPartitionKey(organization, project, pullRequestId));
                 if (list.Count > 0)
                 {
                     itemsAdded = list.Count;
@@ -120,7 +120,7 @@ namespace DevOpsMetrics.Tests.Service
         }
 
         [TestMethod]
-        public void AzGetAzDoDevOpsMetricsLogsDAIntegrationTest()
+        public async Task AzGetAzDoDevOpsMetricsLogsDAIntegrationTest()
         {
             //Arrange
             TableStorageConfiguration tableStorageConfig = Common.GenerateTableStorageConfiguration(base.Configuration);
@@ -130,7 +130,7 @@ namespace DevOpsMetrics.Tests.Service
 
             //Act
             AzureTableStorageDA da = new();
-            List<ProjectLog> logs = da.GetProjectLogsFromStorage(tableStorageConfig, PartitionKeys.CreateAzureDevOpsSettingsPartitionKey(organization, project, repository));
+            List<ProjectLog> logs = await da.GetProjectLogsFromStorage(tableStorageConfig, PartitionKeys.CreateAzureDevOpsSettingsPartitionKey(organization, project, repository));
 
             //Assert
             Assert.IsTrue(logs != null);
@@ -138,7 +138,7 @@ namespace DevOpsMetrics.Tests.Service
         }
 
         [TestMethod]
-        public void GHGetBuildsDAIntegrationTest()
+        public async Task GHGetBuildsDAIntegrationTest()
         {
             //Arrange
             TableStorageConfiguration tableStorageConfig = Common.GenerateTableStorageConfiguration(base.Configuration);
@@ -148,7 +148,7 @@ namespace DevOpsMetrics.Tests.Service
 
             //Act
             AzureTableStorageDA da = new();
-            JArray list = da.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableGitHubRuns, PartitionKeys.CreateBuildWorkflowPartitionKey(owner, repo, workflowName));
+            JArray list = await da.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableGitHubRuns, PartitionKeys.CreateBuildWorkflowPartitionKey(owner, repo, workflowName));
 
             //Assert
             Assert.IsTrue(list.Count >= 0);
@@ -203,7 +203,7 @@ namespace DevOpsMetrics.Tests.Service
         }
 
         [TestMethod]
-        public void GHGetPRsDAIntegrationTest()
+        public async Task GHGetPRsDAIntegrationTest()
         {
             //Arrange
             TableStorageConfiguration tableStorageConfig = Common.GenerateTableStorageConfiguration(base.Configuration);
@@ -212,7 +212,7 @@ namespace DevOpsMetrics.Tests.Service
 
             //Act
             AzureTableStorageDA da = new();
-            JArray list = da.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableGitHubPRs, PartitionKeys.CreateGitHubPRPartitionKey(owner, repo));
+            JArray list = await da.GetTableStorageItemsFromStorage(tableStorageConfig, tableStorageConfig.TableGitHubPRs, PartitionKeys.CreateGitHubPRPartitionKey(owner, repo));
 
             //Assert
             Assert.IsTrue(list.Count >= 0);
@@ -263,7 +263,7 @@ namespace DevOpsMetrics.Tests.Service
         }
 
         [TestMethod]
-        public void GHGetSamsFeatureFlagsLogsDAIntegrationTest()
+        public async Task GHGetSamsFeatureFlagsLogsDAIntegrationTest()
         {
             //Arrange
             TableStorageConfiguration tableStorageConfig = Common.GenerateTableStorageConfiguration(base.Configuration);
@@ -272,7 +272,7 @@ namespace DevOpsMetrics.Tests.Service
 
             //Act
             AzureTableStorageDA da = new();
-            List<ProjectLog> logs = da.GetProjectLogsFromStorage(tableStorageConfig, PartitionKeys.CreateGitHubSettingsPartitionKey(owner, repo));
+            List<ProjectLog> logs = await da.GetProjectLogsFromStorage(tableStorageConfig, PartitionKeys.CreateGitHubSettingsPartitionKey(owner, repo));
 
             //Assert
             Assert.IsTrue(logs != null);


### PR DESCRIPTION
Fixes #856 

By adding task parallelism, we can improve performance ~50% (for a full DORA summary, from ~50s to ~25s total processing time)

Also upgrading the `Microsoft.Azure.Cosmos.Table` package to `Azure.Data.Tables` to take advantage of the benefits this provides (especially given most of the time is processing the Azure Table Storage)